### PR TITLE
yext/teamcity: move PropertyFromName to a Params method

### DIFF
--- a/build.go
+++ b/build.go
@@ -47,6 +47,7 @@ type BuildType struct {
 	Project              *Project              `json:"project,omitempty"`
 	VcsRootEntries       *VcsRootEntries       `json:"vcs-root-entries"`
 	Template             *BuildType            `json:"template,omitempty"`
+	Properties           Params                `json:"properties,omitempty"`
 }
 
 // BuildTypes is a container for a list of BuildType's

--- a/project.go
+++ b/project.go
@@ -27,12 +27,17 @@ type Property struct {
 	Own   bool   `json:"own,omitempty"`
 }
 
-// getProperty returns the Property of the given project with the given target name if it exists
-func (project Project) PropertyFromName(target string) Property {
-	for _, property := range project.Params.Properties {
+// PropertyFromName returns the Property of the given Params with the given target name if it exists
+func (params Params) PropertyFromName(target string) Property {
+	for _, property := range params.Properties {
 		if property.Name == target {
 			return property
 		}
 	}
 	return Property{}
+}
+
+// PropertyFromName returns the Property of the given Project with the given target name if it exists
+func (project Project) PropertyFromName(target string) Property {
+	return project.Params.PropertyFromName(target)
 }


### PR DESCRIPTION
created on behalf of @BOTBrad 

Both Builds and Projects have a Params member, moving the PropertyFromName
function to be a member method of Params instead of Project means both
can use it with minimal refactoring.

The old version of the function will be kept to maintain compatibility.
Properties is also added to the BuildType struct as it's returned for
build types but currently discarded.