### PR TITLE
Make Parameters a pointer to a struct in BuildType

### DIFF
--- a/build.go
+++ b/build.go
@@ -47,7 +47,7 @@ type BuildType struct {
 	Project              *Project              `json:"project,omitempty"`
 	VcsRootEntries       *VcsRootEntries       `json:"vcs-root-entries"`
 	Template             *BuildType            `json:"template,omitempty"`
-	Parameters           Params                `json:"parameters,omitempty"`
+	Parameters           *Params               `json:"parameters,omitempty"`
 }
 
 // BuildTypes is a container for a list of BuildType's


### PR DESCRIPTION
omitempty does not work for structs directly, only for pointers to structs

r=atavakoli

TEST=manual
omitted when there are no parameters locally